### PR TITLE
changing output encoding from ISO-8859-1 to UTF-8

### DIFF
--- a/src/main/java/org/taktik/icure/be/format/logic/impl/HealthOneLogicImpl.java
+++ b/src/main/java/org/taktik/icure/be/format/logic/impl/HealthOneLogicImpl.java
@@ -700,7 +700,7 @@ public class HealthOneLogicImpl extends GenericResultFormatLogicImpl implements 
 	public void doExport(HealthcareParty sender, HealthcareParty recipient, Patient patient, LocalDateTime date, String ref, String text, OutputStream output) {
 		PrintWriter pw;
 		try {
-			pw = new PrintWriter(new OutputStreamWriter(output, "ISO-8859-1"));
+			pw = new PrintWriter(new OutputStreamWriter(output, "UTF-8"));
 		} catch (UnsupportedEncodingException e) {
 			throw new IllegalStateException(e);
 		}

--- a/src/main/java/org/taktik/icure/be/format/logic/impl/MedidocLogicImpl.java
+++ b/src/main/java/org/taktik/icure/be/format/logic/impl/MedidocLogicImpl.java
@@ -284,7 +284,7 @@ public class MedidocLogicImpl extends GenericResultFormatLogicImpl implements Me
 	public void doExport(HealthcareParty sender, HealthcareParty recipient, Patient patient, LocalDateTime date, String ref, String text, OutputStream output) {
 		PrintWriter pw;
 		try {
-			pw = new PrintWriter(new OutputStreamWriter(output, "ISO-8859-1"));
+			pw = new PrintWriter(new OutputStreamWriter(output, "UTF-8"));
 		} catch (UnsupportedEncodingException e) {
 			throw new IllegalStateException(e);
 		}


### PR DESCRIPTION
Currently, the OutputStreamWriter in Java for the export of medidoc and healthone (see HealthOneImpl.java and MedidocLogicImpl.java) is set such that the output encoding is ISO-8859-1 (latin-1). This causes encoding conflicts during the exports between frontend (which sends data as UTF-8 and expects UTF-8 answers) and backend (which reads as UTF-8 but exports ISO-8859-1).

We propose to change the output encoding to UTF-8 instead of ISO-8859-1.

We do not expect strong backend compatibility problems, because we have found another problem during the investigation: backend does not seem to be able to understand data coming as encoded in ISO-8859-1. Indeed, Backend tests for two windows encodings, then turns to UTF-8, not ISO-8859-1. The modification we propose makes backend more robust for future exports, and is expected to perform as well as the current version.