### PR TITLE
[MS-3624] move specialists to a new hcparty tag within the sender tag

### DIFF
--- a/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/note/impl/v20161201/KmehrNoteLogicImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/note/impl/v20161201/KmehrNoteLogicImpl.kt
@@ -47,6 +47,7 @@ class KmehrNoteLogicImpl : KmehrNoteLogic, KmehrExport() {
                 this.time = makeXGC(Instant.now().toEpochMilli())
                 this.sender = SenderType().apply {
                     hcparties.add(createParty(author, emptyList()))
+                    hcparties.add(createSpecialistParty(author, emptyList()))
                     hcparties.add(HcpartyType().apply { this.cds.addAll(listOf(CDHCPARTY().apply { s(CDHCPARTYschemes.CD_HCPARTY); value="application" })); this.name = "${config.soft?.name} ${config.soft?.version}" })
                 }
                 val recipient = HealthcareParty().apply {

--- a/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/v20161201/KmehrExport.kt
+++ b/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/v20161201/KmehrExport.kt
@@ -94,13 +94,8 @@ open class KmehrExport {
             }
             cds?.let {this.cds.addAll(it)}
 			this.cds.addAll(
-				if (m.specialityCodes?.size ?: 0 > 0){
-					m.specialityCodes.map { CDHCPARTY().apply { s(CDHCPARTYschemes.CD_HCPARTY); value = it.code } }
-                } else if (m.speciality?: "" != ""){
-                    listOf(CDHCPARTY().apply { s(CDHCPARTYschemes.CD_HCPARTY); value = m.speciality })
-                }
-				else
-					listOf(CDHCPARTY().apply { s(CDHCPARTYschemes.CD_HCPARTY); value = "persphysician" }))
+					listOf(CDHCPARTY().apply { s(CDHCPARTYschemes.CD_HCPARTY); value = "persphysician" })
+            )
 
             if (this.cds.filter { it.s == CDHCPARTYschemes.CD_HCPARTY }.any {it.value.startsWith("pers")}) {
                 firstname = m.firstName
@@ -114,6 +109,20 @@ open class KmehrExport {
 
             addresses.addAll(makeAddresses(m.addresses))
             telecoms.addAll(makeTelecoms(m.addresses))
+        }
+    }
+
+    fun createSpecialistParty(m: HealthcareParty, cds: List<CDHCPARTY>? = listOf() ): HcpartyType {
+        return HcpartyType().apply {
+            cds?.let {this.cds.addAll(it)}
+            this.cds.addAll(
+                if (m.specialityCodes?.size ?: 0 > 0){
+                    m.specialityCodes.map { CDHCPARTY().apply { s(CDHCPARTYschemes.CD_HCPARTY); value = it.code } }
+                } else if (m.speciality?: "" != ""){
+                    listOf(CDHCPARTY().apply { s(CDHCPARTYschemes.CD_HCPARTY); value = m.speciality })
+                }
+                else
+                    listOf(CDHCPARTY().apply { s(CDHCPARTYschemes.CD_HCPARTY); value = "persphysician" }))
         }
     }
 


### PR DESCRIPTION
See https://medispring.atlassian.net/browse/MS-3624

Refers to the following email, which instructed us to change the XML payload. Ideally this modification would be done on the `icure-backend` side, as this PR accomplishes. Excerpt from the email (from RSW, regarding the ticket `HELPDESK-13309`)

---------------------------
Bonjour,

Le support confirmera/complètera mais pour moi :

 

Au niveau de l’auteur de la transaction je vois ceci

 

                                 <ns3:hcparty>

                                       <ns3:id S="ID-HCPARTY" SV="1.0">************</ns3:id>

                                       <ns3:id S="INSS" SV="1.0">************</ns3:id>

                                       <ns3:cd S="CD-HCPARTY" SV="1.11">deptphysiotherapy</ns3:cd>

                                       <ns3:name>************</ns3:name>

                                       <ns3:address>

                                              <ns3:cd S="CD-ADDRESS" SV="1.1">work</ns3:cd>

                                              <ns3:country>

                                                    <ns3:cd S="CD-FED-COUNTRY" SV="1.2">be</ns3:cd>

                                              </ns3:country>

                                              <ns3:zip>************</ns3:zip>

                                              <ns3:city>************</ns3:city>

                                              <ns3:street>************</ns3:street>

                                              <ns3:housenumber>32</ns3:housenumber>

                                       </ns3:address>

                                       <ns3:telecom>

                                              <ns3:cd S="CD-ADDRESS" SV="1.1">work</ns3:cd>

                                              <ns3:cd S="CD-TELECOM" SV="1.0">phone</ns3:cd>

                                              <ns3:telecomnumber>************</ns3:telecomnumber>

                                       </ns3:telecom>

                                 </ns3:hcparty>

 

 

C’est incorrect.

La catégorie professionnelle d’un médecin ce qui correspond au code Kmehr persphysician.

Qu’il s’agisse d’un spécialiste ou d’un généraliste ca n’y change rien.

C’est lorsqu’on change de profession au sens de l’AR78 qu’on change ce code (par exemple pour un infirmier, une sage-femme, un pharmacien  etc …)

 

Là vous indiquez, qui plus est, quelque chose d’incohérent avec ce qui est fourni plus haut dans la requête.

 

Pour spécifier une spécialité médicale au niveau Kmehr , il faut ajouter un élément  hcparty, par exemple pour un gynécologue

 
```-xml
<hcparty>

   <cd SV="1.0" S="CD-HCPARTY">deptgynecology</cd>

</hcparty>
```
---------------------------

PR has been tested on local instance of `icure-backend` and successfully sent specialist messages to HUB.