### PR TITLE
Improve authentication invalidation

### DIFF
--- a/src/main/kotlin/org/taktik/icure/security/SecurityContextProvider.kt
+++ b/src/main/kotlin/org/taktik/icure/security/SecurityContextProvider.kt
@@ -1,0 +1,12 @@
+package org.taktik.icure.security
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.reactor.ReactorContext
+import org.springframework.security.core.context.SecurityContext
+import reactor.core.publisher.Mono
+import kotlin.coroutines.coroutineContext
+
+@ExperimentalCoroutinesApi
+suspend fun loadSecurityContext(): Mono<SecurityContext>? {
+    return coroutineContext[ReactorContext]?.context?.get<Mono<SecurityContext>>(SecurityContext::class.java)
+}


### PR DESCRIPTION
Suggestion regarding hard override of the authentication object within the SecurityContext.

The hard authentication=null override generates null pointer exception in the Spring SecurityContextServerWebExchange. 

As a consequence, a 500 error is thrown by the server while the client expect a standard 401. 

Also, the PR introduce a first level function to provide access to the SecurityContext embedded in the coroutine context (via the standard Reactor Context)

