### PR TITLE
add delegationTag anonymousMedicalInformation

### DIFF
--- a/src/main/java/org/taktik/icure/entities/embed/DelegationTag.java
+++ b/src/main/java/org/taktik/icure/entities/embed/DelegationTag.java
@@ -21,6 +21,7 @@ package org.taktik.icure.entities.embed;
 public enum DelegationTag {
 	all,
 	administrativeData,
+	anonymousMedicalInformation,
 	generalInformation,
 	financialInformation,
 	medicalInformation,


### PR DESCRIPTION
The anonymousMedicalInformation tag is created to allow sharing medical information in an anonymous way (no delegations or cryptedForeignKeys, only encryptionKeys). This tag will be used for sharing information with an "Extractor user", i.e. an AI user which analyses the data to predict inputs. This is part of a POC for the "Tremplin IA" project.