### PR TITLE
MS-6666 Add getCalendarItemsByRecurrenceId() endpoint + refactor calendarItem/DELETE

### DIFF
--- a/src/main/java/org/taktik/icure/dao/CalendarItemDAO.java
+++ b/src/main/java/org/taktik/icure/dao/CalendarItemDAO.java
@@ -40,4 +40,6 @@ public interface CalendarItemDAO extends GenericDAO<CalendarItem> {
     List<CalendarItem> listCalendarItemByPeriodAndAgendaId(Long startDate, Long endDate, String agendaId);
 
     List<CalendarItem> findByHCPartySecretPatientKeys(String hcPartyId, List<String> secretPatientKeys);
+
+    List<CalendarItem> findByRecurrenceId (String recurrenceId);
 }

--- a/src/main/java/org/taktik/icure/dao/impl/CalendarItemDAOImpl.java
+++ b/src/main/java/org/taktik/icure/dao/impl/CalendarItemDAOImpl.java
@@ -91,7 +91,7 @@ public class CalendarItemDAOImpl extends GenericDAOImpl<CalendarItem> implements
     }
 
     @Override
-    @View(name = "by_recurrence_id", map = "function(doc) {  if (doc.java_type == 'org.taktik.icure.entities.CalendarItem' && !doc.deleted) {emit(doc.recurrenceId,doc._id)}}")
+    @View(name = "by_recurrence_id", map = "classpath:js/calendarItem/by_recurrence_id.js")
     public List<CalendarItem> findByRecurrenceId(String recurrenceId) {
         return queryView("by_recurrence_id", recurrenceId);
     }

--- a/src/main/java/org/taktik/icure/dao/impl/CalendarItemDAOImpl.java
+++ b/src/main/java/org/taktik/icure/dao/impl/CalendarItemDAOImpl.java
@@ -29,6 +29,7 @@ import org.taktik.icure.dao.impl.ektorp.CouchDbICureConnector;
 import org.taktik.icure.dao.impl.idgenerators.IDGenerator;
 import org.taktik.icure.entities.AccessLog;
 import org.taktik.icure.entities.CalendarItem;
+import org.taktik.icure.entities.User;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -88,6 +89,13 @@ public class CalendarItemDAOImpl extends GenericDAOImpl<CalendarItem> implements
 
         return calendarItems;
     }
+
+    @Override
+    @View(name = "by_recurrence_id", map = "function(doc) {  if (doc.java_type == 'org.taktik.icure.entities.CalendarItem' && !doc.deleted) {emit(doc.recurrenceId,doc._id)}}")
+    public List<CalendarItem> findByRecurrenceId(String recurrenceId) {
+        return queryView("by_recurrence_id", recurrenceId);
+    }
+
 
     @Override
     public List<CalendarItem> listCalendarItemByPeriodAndHcPartyId(Long startDate, Long endDate, String hcPartyId) {

--- a/src/main/java/org/taktik/icure/logic/CalendarItemLogic.java
+++ b/src/main/java/org/taktik/icure/logic/CalendarItemLogic.java
@@ -43,4 +43,6 @@ public interface CalendarItemLogic extends EntityPersister<CalendarItem, String>
     List<String> deleteCalendarItems(List<String> ids) throws DeletionException;
 
     List<CalendarItem> getCalendarItemByIds(List<String> ids);
+
+    List<CalendarItem> getCalendarItemsByRecurrenceId(String recurenceId);
 }

--- a/src/main/java/org/taktik/icure/logic/impl/CalendarItemLogicImpl.java
+++ b/src/main/java/org/taktik/icure/logic/impl/CalendarItemLogicImpl.java
@@ -30,7 +30,6 @@ import java.util.List;
 
 @Service
 public class CalendarItemLogicImpl extends GenericLogicImpl<CalendarItem, CalendarItemDAO> implements CalendarItemLogic {
-
 	private CalendarItemDAO calendarItemDAO;
 	private ICureSessionLogic sessionLogic;
 
@@ -77,6 +76,11 @@ public class CalendarItemLogicImpl extends GenericLogicImpl<CalendarItem, Calend
     @Override
     public List<CalendarItem> getCalendarItemByIds(List<String> ids) {
         return calendarItemDAO.getList(ids);
+    }
+
+    @Override
+    public List<CalendarItem> getCalendarItemsByRecurrenceId (String recurrenceId) {
+        return calendarItemDAO.findByRecurrenceId (recurrenceId);
     }
 
     @Autowired

--- a/src/main/java/org/taktik/icure/services/external/rest/v1/facade/CalendarItemFacade.java
+++ b/src/main/java/org/taktik/icure/services/external/rest/v1/facade/CalendarItemFacade.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.taktik.icure.entities.CalendarItem;
 import org.taktik.icure.entities.embed.Delegation;
 import org.taktik.icure.exceptions.DeletionException;
@@ -88,23 +89,22 @@ public class CalendarItemFacade implements OpenApiFacade {
 
 
     @ApiOperation(value = "Deletes calendarItems")
-    @DELETE
-    @Path("/{calendarItemIds}")
-    public Response deleteCalendarItem(@PathParam("calendarItemIds") String calendarItemIds) throws DeletionException {
+    @POST
+    @Path("/deleteCalendarItems")
+    public Response deleteCalendarItems(@RequestBody List<String> calendarItemIds) throws DeletionException {
         Response response;
 
         if (calendarItemIds == null) {
             response = ResponseUtils.badRequest("Cannot delete access log: supplied calendarItemIds is null");
 
         } else {
-            List<String> deletedCalendarItemIds = calendarItemLogic.deleteCalendarItems(Arrays.asList(calendarItemIds.split(",")));
+            List<String> deletedCalendarItemIds = calendarItemLogic.deleteCalendarItems(calendarItemIds);
             if (deletedCalendarItemIds != null) {
                 response = Response.ok().entity(deletedCalendarItemIds).build();
             } else {
                 return Response.status(500).type("text/plain").entity("CalendarItem deletion failed.").build();
             }
         }
-
         return response;
     }
 

--- a/src/main/java/org/taktik/icure/services/external/rest/v1/facade/CalendarItemFacade.java
+++ b/src/main/java/org/taktik/icure/services/external/rest/v1/facade/CalendarItemFacade.java
@@ -90,7 +90,7 @@ public class CalendarItemFacade implements OpenApiFacade {
 
     @ApiOperation(value = "Deletes calendarItems")
     @POST
-    @Path("/deleteCalendarItems")
+    @Path("/delete")
     public Response deleteCalendarItems(@RequestBody List<String> calendarItemIds) throws DeletionException {
         Response response;
 

--- a/src/main/java/org/taktik/icure/services/external/rest/v1/facade/CalendarItemFacade.java
+++ b/src/main/java/org/taktik/icure/services/external/rest/v1/facade/CalendarItemFacade.java
@@ -86,7 +86,8 @@ public class CalendarItemFacade implements OpenApiFacade {
         return response;
     }
 
-    @ApiOperation(value = "Deletes an calendarItem")
+
+    @ApiOperation(value = "Deletes calendarItems")
     @DELETE
     @Path("/{calendarItemIds}")
     public Response deleteCalendarItem(@PathParam("calendarItemIds") String calendarItemIds) throws DeletionException {
@@ -276,6 +277,27 @@ public class CalendarItemFacade implements OpenApiFacade {
 
         } else {
             response = ResponseUtils.internalServerError("CalendarItemTypes fetching failed");
+        }
+        return response;
+    }
+
+    @ApiOperation(
+            value = "Gets calendarItems by recurrenceId",
+            response = CalendarItemDto.class,
+            responseContainer = "Array",
+            httpMethod = "GET",
+            notes = ""
+    )
+    @GET
+    @Path("/byRecurrenceId")
+    public Response getCalendarItemsByRecurrenceId(@QueryParam("recurrenceId") String recurrenceId) {
+        Response response;
+        List<CalendarItem> calendarItems = calendarItemLogic.getCalendarItemsByRecurrenceId(recurrenceId);
+        if (calendarItems != null) {
+            response = Response.ok().entity(calendarItems.stream().map(c -> mapper.map(c, CalendarItemDto.class)).collect(Collectors.toList())).build();
+
+        } else {
+            response = ResponseUtils.internalServerError("CalendarItems by recurrenceId fetching failed");
         }
         return response;
     }

--- a/src/main/resources/org/taktik/icure/dao/impl/js/calendarItem/by_recurrence_id.js
+++ b/src/main/resources/org/taktik/icure/dao/impl/js/calendarItem/by_recurrence_id.js
@@ -1,0 +1,5 @@
+map = function (doc) {
+    if (doc.java_type === 'org.taktik.icure.entities.CalendarItem' && !doc.deleted) {
+        emit(doc.recurrenceId, doc._id);
+    }
+};


### PR DESCRIPTION
- adds getCalendarItemsByRecurrenceId() endpoint
- refactor calendarItem/DELETE  in order to pass an array instead of comma-separated strings. 