### PR TITLE
[KRAKEN] MS-7366 fix design documents deletion

### DIFF
--- a/src/main/kotlin/org/taktik/icure/asyncdao/VersionedDesignDocumentQueries.kt
+++ b/src/main/kotlin/org/taktik/icure/asyncdao/VersionedDesignDocumentQueries.kt
@@ -22,7 +22,7 @@ import org.taktik.icure.properties.CouchDbProperties
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
-open class VersionnedDesignDocumentQueries<T : StoredDocument>(protected open val entityClass: Class<T>, private val couchdDbProperties: CouchDbProperties) {
+open class VersionedDesignDocumentQueries<T : StoredDocument>(protected open val entityClass: Class<T>, private val couchdDbProperties: CouchDbProperties) {
 
     private val designDocIdProvider = CacheBuilder.newBuilder()
             .maximumSize(100)
@@ -34,7 +34,7 @@ open class VersionnedDesignDocumentQueries<T : StoredDocument>(protected open va
                         val client = key.first
                         val baseId = designDocName(key.second)
                         val relatedDesignDocs = client.designDocumentsIds().filter { if (it.length == baseId.length) it.startsWith(baseId) else it.startsWith("${baseId}_") }
-                        val generatedDesignDocument = StdDesignDocumentFactory().generateFrom(baseId, this@VersionnedDesignDocumentQueries)
+                        val generatedDesignDocument = StdDesignDocumentFactory().generateFrom(baseId, this@VersionedDesignDocumentQueries)
                         return@async if (relatedDesignDocs.size == 1) {
                             relatedDesignDocs.first()
                         } else if (relatedDesignDocs.contains(generatedDesignDocument.id) && isReadyDesignDoc(client, generatedDesignDocument.id)) {

--- a/src/main/kotlin/org/taktik/icure/asyncdao/VersionnedDesignDocumentQueries.kt
+++ b/src/main/kotlin/org/taktik/icure/asyncdao/VersionnedDesignDocumentQueries.kt
@@ -33,7 +33,7 @@ open class VersionnedDesignDocumentQueries<T : StoredDocument>(protected open va
                     return GlobalScope.async {
                         val client = key.first
                         val baseId = designDocName(key.second)
-                        val relatedDesignDocs = client.designDocumentsIds().filter { it.startsWith(baseId) }
+                        val relatedDesignDocs = client.designDocumentsIds().filter { if (it.length == baseId.length) it.startsWith(baseId) else it.startsWith("${baseId}_") }
                         val generatedDesignDocument = StdDesignDocumentFactory().generateFrom(baseId, this@VersionnedDesignDocumentQueries)
                         return@async if (relatedDesignDocs.size == 1) {
                             relatedDesignDocs.first()

--- a/src/main/kotlin/org/taktik/icure/asyncdao/impl/GenericDAOImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asyncdao/impl/GenericDAOImpl.kt
@@ -33,7 +33,7 @@ import org.taktik.couchdb.exception.UpdateConflictException
 import org.taktik.couchdb.id.IDGenerator
 import org.taktik.couchdb.support.StdDesignDocumentFactory
 import org.taktik.icure.asyncdao.GenericDAO
-import org.taktik.icure.asyncdao.VersionnedDesignDocumentQueries
+import org.taktik.icure.asyncdao.VersionedDesignDocumentQueries
 import org.taktik.icure.entities.base.StoredDocument
 import org.taktik.icure.exceptions.BulkUpdateConflictException
 import org.taktik.icure.exceptions.PersistenceException
@@ -45,7 +45,7 @@ import java.nio.ByteBuffer
 @ExperimentalCoroutinesApi
 abstract class GenericDAOImpl<T : StoredDocument>(couchDbProperties: CouchDbProperties,
                                                   protected override val entityClass: Class<T>, protected val couchDbDispatcher: CouchDbDispatcher, protected val idGenerator: IDGenerator
-) : GenericDAO<T>, VersionnedDesignDocumentQueries<T>(entityClass, couchDbProperties) {
+) : GenericDAO<T>, VersionedDesignDocumentQueries<T>(entityClass, couchDbProperties) {
     private val log = LoggerFactory.getLogger(this.javaClass)
     protected val dbInstanceUrl = URI(couchDbProperties.url)
 

--- a/src/main/kotlin/org/taktik/icure/asyncdao/impl/InternalDAOImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asyncdao/impl/InternalDAOImpl.kt
@@ -35,14 +35,14 @@ import org.taktik.couchdb.queryView
 import org.taktik.couchdb.support.StdDesignDocumentFactory
 import org.taktik.couchdb.update
 import org.taktik.icure.asyncdao.InternalDAO
-import org.taktik.icure.asyncdao.VersionnedDesignDocumentQueries
+import org.taktik.icure.asyncdao.VersionedDesignDocumentQueries
 import org.taktik.icure.entities.base.StoredDocument
 import org.taktik.icure.properties.CouchDbProperties
 import java.net.URI
 
 @ExperimentalCoroutinesApi
 @FlowPreview
-open class InternalDAOImpl<T : StoredDocument>(override val entityClass: Class<T>, val couchDbProperties: CouchDbProperties, val couchDbDispatcher: CouchDbDispatcher, val idGenerator: IDGenerator) : InternalDAO<T>, VersionnedDesignDocumentQueries<T>(entityClass, couchDbProperties) {
+open class InternalDAOImpl<T : StoredDocument>(override val entityClass: Class<T>, val couchDbProperties: CouchDbProperties, val couchDbDispatcher: CouchDbDispatcher, val idGenerator: IDGenerator) : InternalDAO<T>, VersionedDesignDocumentQueries<T>(entityClass, couchDbProperties) {
     private val log = LoggerFactory.getLogger(javaClass)
     //private val client = couchDbDispatcher.getClient(URI(couchDbProperties.url))
 


### PR DESCRIPTION
Fix bug when we have two design docs like _design/CalendarItem_XXXX and _design/CalendarItemType_XXXX.

The VersionedDesignDocumentQueries logic deletes the design/CalendarItemType_XXXX because it starts with baseId "_design/CalendarItem".
