### PR TITLE
bugfix/MS-7774_ignore-files-exported-in-specific-directory-for-HealthOne

### DIFF
--- a/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/smf/impl/v23g/SoftwareMedicalFileImport.kt
+++ b/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/smf/impl/v23g/SoftwareMedicalFileImport.kt
@@ -350,7 +350,7 @@ class SoftwareMedicalFileImport(
 		val trnauthorhcpid = extractTransactionAuthor(trn, saveToDatabase, author, v)
 		val trnTypeCd = trn.cds.find { it.s == CDTRANSACTIONschemes.CD_TRANSACTION_TYPE }?.value
 
-		val services = trn.headingsAndItemsAndTexts?.filterIsInstance(LnkType::class.java)?.filter { it.type == CDLNKvalues.MULTIMEDIA }?.map { lnk ->
+		val services = trn.headingsAndItemsAndTexts?.filterIsInstance(LnkType::class.java)?.filter { it.type == CDLNKvalues.MULTIMEDIA && it.url?.subSequence(0,8) != "PmfFiles" }?.map { lnk ->
 			val docname = trn.cds.firstOrNull { it.s == CDTRANSACTIONschemes.CD_TRANSACTION }?.dn ?: trnTypeCd ?: "unnamed_document"
 			val svcRecordDateTime = trn.recorddatetime?.toGregorianCalendar()?.toInstant()?.toEpochMilli()
 

--- a/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/smf/impl/v23g/SoftwareMedicalFileImport.kt
+++ b/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/smf/impl/v23g/SoftwareMedicalFileImport.kt
@@ -350,7 +350,7 @@ class SoftwareMedicalFileImport(
 		val trnauthorhcpid = extractTransactionAuthor(trn, saveToDatabase, author, v)
 		val trnTypeCd = trn.cds.find { it.s == CDTRANSACTIONschemes.CD_TRANSACTION_TYPE }?.value
 
-		val services = trn.headingsAndItemsAndTexts?.filterIsInstance(LnkType::class.java)?.filter { it.type == CDLNKvalues.MULTIMEDIA && it.url?.subSequence(0,8) != "PmfFiles" }?.map { lnk ->
+		val services = trn.headingsAndItemsAndTexts?.filterIsInstance(LnkType::class.java)?.filter { it.type == CDLNKvalues.MULTIMEDIA && it.url == null }?.map { lnk ->
 			val docname = trn.cds.firstOrNull { it.s == CDTRANSACTIONschemes.CD_TRANSACTION }?.dn ?: trnTypeCd ?: "unnamed_document"
 			val svcRecordDateTime = trn.recorddatetime?.toGregorianCalendar()?.toInstant()?.toEpochMilli()
 


### PR DESCRIPTION
HealthOne ont mis en place ceci pour éviter les problèmes de mémoire de leur logiciel lors de l'export de fichiers de plus de 20Mo. Ils exportent donc les fichiers de plus de 20Mo dans un dossier différent. Le problème c'est que le backend créer quand même un document vide dans ce cas-ci.

![image](https://user-images.githubusercontent.com/67685593/169841038-bee5eafb-c6fb-4106-8a31-79dacc329f7e.png)
