### PR TITLE
bugfix/MS-6718_add-service-in-itemByServiceId-even-if-pmf

### DIFF
--- a/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/smf/impl/v23g/SoftwareMedicalFileExport.kt
+++ b/src/main/kotlin/org/taktik/icure/be/ehealth/logic/kmehr/smf/impl/v23g/SoftwareMedicalFileExport.kt
@@ -665,15 +665,8 @@ class SoftwareMedicalFileExport(
 					)
 				}
 			}
-			itemByServiceId[serviceId] = item
 		}
-	}
-
-	private fun isServiceANewVersionOf(mfId: String): Boolean {
-		itemByServiceId[mfId]?.let {
-			return true
-		}
-		return false
+		itemByServiceId[serviceId] = item
 	}
 
 	private suspend fun makeNursePrescriptionTransaction(contact: Service, language: String, decryptor: AsyncDecrypt?, transactionMfId: String): TransactionType {


### PR DESCRIPTION
This need to be outside of the condition because even if we don't have any history in PMF we still need itemByServiceId to set link between HE and services