### PR TITLE
Added batch creation and batch modification to the Code API endpoints

### DIFF
--- a/src/main/kotlin/org/taktik/icure/asynclogic/CodeLogic.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/CodeLogic.kt
@@ -35,10 +35,12 @@ interface CodeLogic : EntityPersister<Code, String> {
 	fun getCodes(ids: List<String>): Flow<Code>
 	suspend fun create(code: Code): Code?
 
-	suspend fun batchCreate(batch: List<Code>): List<Code>?
+	suspend fun create(batch: List<Code>): List<Code>?
 
 	@Throws(Exception::class)
 	suspend fun modify(code: Code): Code?
+
+	fun modify(batch: List<Code>): Flow<Code>
 
 	fun findCodeTypes(type: String?): Flow<String>
 	fun findCodeTypes(region: String?, type: String?): Flow<String>

--- a/src/main/kotlin/org/taktik/icure/asynclogic/CodeLogic.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/CodeLogic.kt
@@ -35,6 +35,8 @@ interface CodeLogic : EntityPersister<Code, String> {
 	fun getCodes(ids: List<String>): Flow<Code>
 	suspend fun create(code: Code): Code?
 
+	suspend fun batchCreate(batch: List<Code>): List<Code>?
+
 	@Throws(Exception::class)
 	suspend fun modify(code: Code): Code?
 

--- a/src/main/kotlin/org/taktik/icure/asynclogic/impl/CodeLogicImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/impl/CodeLogicImpl.kt
@@ -30,8 +30,10 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.collect.ImmutableMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.count
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
@@ -108,7 +110,7 @@ class CodeLogicImpl(private val sessionLogic: AsyncSessionLogic, val codeDAO: Co
 	}
 
 	// Do we need fix? No annotations on code
-	override suspend fun batchCreate(batch: List<Code>) =
+	override suspend fun create(batch: List<Code>) =
 		batch.fold(setOf<Code>()) { acc, code ->	// First, I check that all the codes are valid
 			code.code ?: error("Code field is null")
 			code.type ?: error("Type field is null")
@@ -121,15 +123,36 @@ class CodeLogicImpl(private val sessionLogic: AsyncSessionLogic, val codeDAO: Co
 			this.getCodes(codeList.map { it.id }).firstOrNull()?.let { duplicatedCode ->
 				error("Code with id ${duplicatedCode.id} already exists")
 			}
-		}.fold(listOf<Code>()) { acc, code ->	// Then, I add the codes
-			codeDAO.create(code)?.let {
-				acc + it
-			} ?: error("Error creating code with id ${code.type}|${code.code}|${code.version}")
-		}
+		}.map { code ->	// Then, I add the codes
+			codeDAO.create(code) ?: error("Error creating code with id ${code.type}|${code.code}|${code.version}")
+		}.toList()
 
 	@Throws(Exception::class)
 	override suspend fun modify(code: Code) = fix(code) { code ->
 		modifyEntities(setOf(code)).firstOrNull()
+	}
+
+	// Do we need fix? No annotations on code
+	override fun modify(batch: List<Code>) = flow {
+		emitAll(modifyEntities(
+			batch.fold(mapOf<String, Code>()) { acc, code ->    // First, I check that all the codes are valid
+				code.code ?: error("Code field is null")
+				code.type ?: error("Type field is null")
+				code.version ?: error("Version field is null")
+				code.rev ?: error("rev field is null")
+
+				if (code.id != "${code.type}|${code.code}|${code.version}") error("Code id does not match the code, type or version value")
+				if (acc.contains(code.id)) error("The batch contains a duplicate")
+
+				acc + (code.id to code)
+			}
+			.map {
+				it.value
+			}
+			.also { codeList ->
+				if (getCodes(codeList.map { it.id }).count() != batch.size) error("You are trying to modify a code that does not exists")
+			}.toSet()
+		))
 	}
 
 	override fun findCodeTypes(type: String?) = flow<String> {

--- a/src/main/kotlin/org/taktik/icure/asynclogic/impl/CodeLogicImpl.kt
+++ b/src/main/kotlin/org/taktik/icure/asynclogic/impl/CodeLogicImpl.kt
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.collect.ImmutableMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.count
@@ -134,25 +133,27 @@ class CodeLogicImpl(private val sessionLogic: AsyncSessionLogic, val codeDAO: Co
 
 	// Do we need fix? No annotations on code
 	override fun modify(batch: List<Code>) = flow {
-		emitAll(modifyEntities(
-			batch.fold(mapOf<String, Code>()) { acc, code ->    // First, I check that all the codes are valid
-				code.code ?: error("Code field is null")
-				code.type ?: error("Type field is null")
-				code.version ?: error("Version field is null")
-				code.rev ?: error("rev field is null")
+		emitAll(
+			modifyEntities(
+				batch.fold(mapOf<String, Code>()) { acc, code -> // First, I check that all the codes are valid
+					code.code ?: error("Code field is null")
+					code.type ?: error("Type field is null")
+					code.version ?: error("Version field is null")
+					code.rev ?: error("rev field is null")
 
-				if (code.id != "${code.type}|${code.code}|${code.version}") error("Code id does not match the code, type or version value")
-				if (acc.contains(code.id)) error("The batch contains a duplicate")
+					if (code.id != "${code.type}|${code.code}|${code.version}") error("Code id does not match the code, type or version value")
+					if (acc.contains(code.id)) error("The batch contains a duplicate")
 
-				acc + (code.id to code)
-			}
-			.map {
-				it.value
-			}
-			.also { codeList ->
-				if (getCodes(codeList.map { it.id }).count() != batch.size) error("You are trying to modify a code that does not exists")
-			}.toSet()
-		))
+					acc + (code.id to code)
+				}
+					.map {
+						it.value
+					}
+					.also { codeList ->
+						if (getCodes(codeList.map { it.id }).count() != batch.size) error("You are trying to modify a code that does not exists")
+					}.toSet()
+			)
+		)
 	}
 
 	override fun findCodeTypes(type: String?) = flow<String> {

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeController.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeController.kt
@@ -27,15 +27,9 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flattenMerge
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.forEach
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.reactor.flux
 import kotlinx.coroutines.reactor.mono
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeController.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeController.kt
@@ -26,9 +26,16 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flattenMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.forEach
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.reactor.flux
 import kotlinx.coroutines.reactor.mono
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -212,7 +219,7 @@ class CodeController(
 	fun createCodes(@RequestBody codeBatch: List<CodeDto>) = mono {
 		val codes = codeBatch.map { codeMapper.map(it) }
 		try {
-			codeLogic.batchCreate(codes)?.map { codeMapper.map(it) }
+			codeLogic.create(codes)?.map { codeMapper.map(it) }
 		} catch (e: IllegalStateException) {
 			throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
 		}
@@ -258,6 +265,17 @@ class CodeController(
 		}
 		modifiedCode?.let { codeMapper.map(it) }
 	}
+
+	@Operation(summary = "Modify a batch of codes", description = "Modification of (type, code, version) is not allowed.")
+	@PutMapping("/batch")
+	fun modifyCodes(@RequestBody codeBatch: List<CodeDto>) =
+		codeLogic.modify(codeBatch.map { codeMapper.map(it) })
+			.catch { e ->
+				if (e is IllegalStateException) throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
+				else throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "A problem regarding modification of the code. Read the app logs: " + e.message)
+			}
+			.map { codeMapper.map(it) }
+			.injectReactorContext()
 
 	@Operation(summary = "Filter codes", description = "Returns a list of codes along with next start keys and Document ID. If the nextStartKey is Null it means that this is the last page.")
 	@PostMapping("/filter")

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeController.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeController.kt
@@ -210,9 +210,7 @@ class CodeController(
 	@Operation(summary = "Create a batch of codes", description = "Create a batch of code entities. Fields Type, Code and Version are required for each code.")
 	@PostMapping("/batch")
 	fun createCodes(@RequestBody codeBatch: List<CodeDto>) = mono {
-		val codes = codeBatch.fold(listOf<Code>()) { acc, c ->
-			acc + codeMapper.map(c)
-		}
+		val codes = codeBatch.map { codeMapper.map(it) }
 		try {
 			codeLogic.batchCreate(codes)?.map { codeMapper.map(it) }
 		} catch (e: IllegalStateException) {

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/CodeDto.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v1/dto/CodeDto.kt
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.taktik.icure.services.external.rest.v1.dto.base.AppendixTypeDto
 import org.taktik.icure.services.external.rest.v1.dto.base.CodeFlagDto
 import org.taktik.icure.services.external.rest.v1.dto.base.CodeIdentificationDto
-import org.taktik.icure.services.external.rest.v1.dto.base.LinkQualificationDto
 import org.taktik.icure.services.external.rest.v1.dto.base.StoredDocumentDto
 import org.taktik.icure.services.external.rest.v1.dto.embed.PeriodicityDto
 

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/CodeController.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/CodeController.kt
@@ -209,6 +209,19 @@ class CodeController(
 		code?.let { codeV2Mapper.map(it) }
 	}
 
+	@Operation(summary = "Create a batch of codes", description = "Create a batch of code entities. Fields Type, Code and Version are required for each code.")
+	@PostMapping("/batch")
+	fun createCodes(@RequestBody codeBatch: List<CodeDto>) = mono {
+		val codes = codeBatch.fold(listOf<Code>()) { acc, c ->
+			acc + codeV2Mapper.map(c)
+		}
+		try {
+			codeLogic.batchCreate(codes)?.map { codeV2Mapper.map(it) }
+		} catch (e: IllegalStateException) {
+			throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
+		}
+	}
+
 	@Operation(summary = "Get a list of codes by ids", description = "Keys must be delimited by coma")
 	@PostMapping("/byIds")
 	fun getCodes(@RequestBody codeIds: ListOfIdsDto): Flux<CodeDto> {

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/CodeController.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/CodeController.kt
@@ -27,10 +27,8 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flattenMerge
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.reactor.mono
 import org.slf4j.LoggerFactory
@@ -276,13 +274,12 @@ class CodeController(
 	@PutMapping("/batch")
 	fun modifyCodes(@RequestBody codeBatch: List<CodeDto>) =
 		codeLogic.modify(codeBatch.map { codeV2Mapper.map(it) })
-		.catch { e ->
-			if (e is IllegalStateException) throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
-			else throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "A problem regarding modification of the code. Read the app logs: " + e.message)
-		}
-		.map { codeV2Mapper.map(it) }
-		.injectReactorContext()
-
+			.catch { e ->
+				if (e is IllegalStateException) throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
+				else throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "A problem regarding modification of the code. Read the app logs: " + e.message)
+			}
+			.map { codeV2Mapper.map(it) }
+			.injectReactorContext()
 
 	@Operation(summary = "Filter codes ", description = "Returns a list of codes along with next start keys and Document ID. If the nextStartKey is Null it means that this is the last page.")
 	@PostMapping("/filter")

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/CodeController.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/CodeController.kt
@@ -26,8 +26,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flattenMerge
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.reactor.mono
 import org.slf4j.LoggerFactory
@@ -214,7 +217,7 @@ class CodeController(
 	fun createCodes(@RequestBody codeBatch: List<CodeDto>) = mono {
 		val codes = codeBatch.map { codeV2Mapper.map(it) }
 		try {
-			codeLogic.batchCreate(codes)?.map { codeV2Mapper.map(it) }
+			codeLogic.create(codes)?.map { codeV2Mapper.map(it) }
 		} catch (e: IllegalStateException) {
 			throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
 		}
@@ -268,6 +271,18 @@ class CodeController(
 		}
 		modifiedCode?.let { codeV2Mapper.map(it) }
 	}
+
+	@Operation(summary = "Modify a batch of codes", description = "Modification of (type, code, version) is not allowed.")
+	@PutMapping("/batch")
+	fun modifyCodes(@RequestBody codeBatch: List<CodeDto>) =
+		codeLogic.modify(codeBatch.map { codeV2Mapper.map(it) })
+		.catch { e ->
+			if (e is IllegalStateException) throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
+			else throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "A problem regarding modification of the code. Read the app logs: " + e.message)
+		}
+		.map { codeV2Mapper.map(it) }
+		.injectReactorContext()
+
 
 	@Operation(summary = "Filter codes ", description = "Returns a list of codes along with next start keys and Document ID. If the nextStartKey is Null it means that this is the last page.")
 	@PostMapping("/filter")

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/CodeController.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v2/controllers/core/CodeController.kt
@@ -212,9 +212,7 @@ class CodeController(
 	@Operation(summary = "Create a batch of codes", description = "Create a batch of code entities. Fields Type, Code and Version are required for each code.")
 	@PostMapping("/batch")
 	fun createCodes(@RequestBody codeBatch: List<CodeDto>) = mono {
-		val codes = codeBatch.fold(listOf<Code>()) { acc, c ->
-			acc + codeV2Mapper.map(c)
-		}
+		val codes = codeBatch.map { codeV2Mapper.map(it) }
 		try {
 			codeLogic.batchCreate(codes)?.map { codeV2Mapper.map(it) }
 		} catch (e: IllegalStateException) {

--- a/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/CodeDto.kt
+++ b/src/main/kotlin/org/taktik/icure/services/external/rest/v2/dto/CodeDto.kt
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import org.taktik.icure.services.external.rest.v2.dto.base.AppendixTypeDto
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeFlagDto
 import org.taktik.icure.services.external.rest.v2.dto.base.CodeIdentificationDto
-import org.taktik.icure.services.external.rest.v2.dto.base.LinkQualificationDto
 import org.taktik.icure.services.external.rest.v2.dto.base.StoredDocumentDto
 import org.taktik.icure.services.external.rest.v2.dto.embed.PeriodicityDto
 

--- a/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeBatchCreationEndToEndTest.kt
+++ b/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeBatchCreationEndToEndTest.kt
@@ -109,7 +109,7 @@ class CodeBatchCreationEndToEndTest @Autowired constructor(
 		// Check that the provided response is correct
 		assertEquals(batch.size, response.size)
 		response.forEach {
-			assert(batch.contains(it))
+			assert(batch.contains(it.copy(rev = null)))
 		}
 
 		// Check that all the new codes are in the database

--- a/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeBatchCreationEndToEndTest.kt
+++ b/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeBatchCreationEndToEndTest.kt
@@ -1,0 +1,274 @@
+package org.taktik.icure.services.external.rest.v1.controllers.core
+
+import java.nio.charset.StandardCharsets
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.SingletonSupport
+import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.test.context.ActiveProfiles
+import org.taktik.icure.asynclogic.CodeLogic
+import org.taktik.icure.services.external.rest.v1.dto.CodeDto
+import org.taktik.icure.services.external.rest.v1.mapper.base.CodeMapper
+import org.taktik.icure.test.CodeBatchGenerator
+import org.taktik.icure.test.ICureTestApplication
+import reactor.core.publisher.Flux
+import reactor.netty.ByteBufFlux
+import reactor.netty.http.client.HttpClient
+
+@SpringBootTest(
+	classes = [ICureTestApplication::class],
+	properties = ["spring.main.allow-bean-definition-overriding=true"],
+	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@ActiveProfiles("app")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CodeBatchCreationEndToEndTest @Autowired constructor(
+	private val codeLogic: CodeLogic,
+	private val codeMapper: CodeMapper
+) {
+
+	@LocalServerPort
+	var port = 0
+	val apiHost = System.getenv("ICURE_BE_URL") ?: "http://localhost"
+	val apiEndpoint: String = System.getenv("ENDPOINT_TO_TEST") ?: "/rest/v1"
+	val codeGenerator = CodeBatchGenerator()
+	val batchSize = 1001
+
+	val objectMapper: ObjectMapper by lazy {
+		ObjectMapper().registerModule(
+			KotlinModule.Builder()
+				.nullIsSameAsDefault(nullIsSameAsDefault = false)
+				.reflectionCacheSize(reflectionCacheSize = 512)
+				.nullToEmptyMap(nullToEmptyMap = false)
+				.nullToEmptyCollection(nullToEmptyCollection = false)
+				.singletonSupport(singletonSupport = SingletonSupport.DISABLED)
+				.strictNullChecks(strictNullChecks = false)
+				.build()
+		)
+	}
+
+	fun createHttpClient(): HttpClient {
+		val auth = "Basic ${java.util.Base64.getEncoder().encodeToString("${System.getenv("ICURE_COUCHDB_TEST_USER")}:${System.getenv("ICURE_COUCHDB_TEST_PWD")}".toByteArray())}"
+		return HttpClient.create().headers { h ->
+			h.set("Authorization", auth) //
+			h.set("Content-type", "application/json")
+		}
+	}
+
+	fun makePostRequest(url: String, payload: String, expectedCode: Int = 200): String? {
+		val client = createHttpClient()
+
+		val responseBody = client
+			.post()
+			.uri(url)
+			.send(ByteBufFlux.fromString(Flux.just(payload)))
+			.responseSingle { response, buffer ->
+				assertNotNull(response)
+				assertEquals(expectedCode, response.status().code())
+				buffer.asString(StandardCharsets.UTF_8)
+			}.block()
+
+		return responseBody
+	}
+
+	@Test
+	fun onEmptyBatchTheResponseIsEmptyAndNoCodeIsAdded() {
+		runBlocking {
+			val batch = listOf<CodeDto>()
+
+			// Get all the codes before the creation
+			val before = codeLogic.findCodesBy(null, null, null)
+
+			val responseString = makePostRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(batch))
+			assertNotNull(responseString)
+			val response = objectMapper.readValue(responseString!!, object : TypeReference<List<CodeDto>>() {})
+			assertEquals(0, response.size)
+
+			// Get all the codes after the creation and compare
+			val after = codeLogic.findCodesBy(null, null, null)
+			assertEquals(before.count(), after.count())
+		}
+	}
+
+	@Test
+	fun batchCreationInEmptyDatabaseExecutesSuccessfully() {
+		val batch = codeGenerator.createBatchOfUniqueCodes(batchSize)
+		val responseString = makePostRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(batch))
+		assertNotNull(responseString)
+		val response = objectMapper.readValue(responseString!!, object : TypeReference<List<CodeDto>>() {})
+
+		// Check that the provided response is correct
+		assertEquals(batch.size, response.size)
+		batch.forEach {
+			assert(batch.contains(it))
+		}
+
+		// Check that all the new codes are in the database
+		val newCodesInDB = codeLogic.getCodes(batch.map { it.id })
+		runBlocking {
+			assertEquals(batch.size, newCodesInDB.count())
+		}
+	}
+
+	@Test
+	fun batchCreationFailsIfAtLeastOneCodeAlreadyExistsInTheDB() {
+		val batch = codeGenerator.createBatchOfUniqueCodes(batchSize)
+
+		runBlocking {
+			// Insert one code in the db
+			codeLogic.create(codeMapper.map(batch[0]))
+
+			// Try creating the codes
+			makePostRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(batch), 400)
+
+			// Check that only the single code exists in the db
+			val newCodesInDB = codeLogic.getCodes(batch.map { it.id })
+			runBlocking {
+				assertEquals(1, newCodesInDB.count())
+			}
+		}
+	}
+
+	fun batchCreationThatFails(batch: List<CodeDto>) {
+		makePostRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(batch), 400)
+
+		// Check that none of the new codes exist in the DB
+		val newCodesInDB = codeLogic.getCodes(batch.map { it.id })
+		runBlocking {
+			assertEquals(0, newCodesInDB.count())
+		}
+	}
+
+	@Test
+	fun batchCreationFailsIfAtLeastOneElementOfTheBatchIsDuplicated() {
+		val batch = codeGenerator.createBatchOfUniqueCodes(batchSize)
+
+		// Try creating the codes, append one existing code to the batch
+		batchCreationThatFails(batch + batch[0])
+	}
+
+	@Test
+	fun batchCreationFailsIfAtLeastOneCodeInTheBatchHasNullCode() {
+		val batch = codeGenerator.createBatchOfUniqueCodes(batchSize)
+
+		// Try creating the codes, append one code with null code to the batch
+		batchCreationThatFails(batch + batch[0].copy(code = null))
+	}
+
+	@Test
+	fun batchCreationFailsIfAtLeastOneCodeInTheBatchHasNullType() {
+		val batch = codeGenerator.createBatchOfUniqueCodes(batchSize)
+
+		// Try creating the codes, append one code with null type to the batch
+		batchCreationThatFails(batch + batch[0].copy(type = null))
+	}
+
+	@Test
+	fun batchCreationFailsIfAtLeastOneCodeInTheBatchHasNullVersion() {
+		val batch = codeGenerator.createBatchOfUniqueCodes(batchSize)
+
+		// Try creating the codes, append one code with null version to the batch
+		batchCreationThatFails(batch + batch[0].copy(version = null))
+	}
+
+	@Test
+	fun batchCreationFailsIfLabelIsNotMap() {
+		val batch = codeGenerator.createBatchOfUniqueCodes(batchSize) + CodeDto(
+			id = "DUMMY_TYPE|DUMMY_CODE|DUMMY_VERSION",
+			type = "DUMMY_TYPE",
+			code = "DUMMY_CODE",
+			version = "DUMMY_VERSION",
+			label = mapOf("DUMMY_LANG" to "DUMMY_VAL")
+		)
+		val stringBatch = objectMapper.writeValueAsString(batch)
+
+		makePostRequest(
+			"$apiHost:$port$apiEndpoint",
+			stringBatch.replace("\\{ *\"DUMMY_LANG\" *: *\"DUMMY_VAL\" *}".toRegex(), "\"DUMMY\""), 400
+		)
+
+		// Check that none of the new codes exist in the DB
+		val newCodesInDB = codeLogic.getCodes(batch.map { it.id })
+		runBlocking {
+			assertEquals(0, newCodesInDB.count())
+		}
+	}
+
+	@Test
+	fun batchCreationFailsIfRegionsIsNotASet() {
+		val batch = codeGenerator.createBatchOfUniqueCodes(batchSize) + CodeDto(
+			id = "DUMMY_TYPE|DUMMY_CODE|DUMMY_VERSION",
+			type = "DUMMY_TYPE",
+			code = "DUMMY_CODE",
+			version = "DUMMY_VERSION",
+			regions = setOf("DUMMY_REGION")
+		)
+		val stringBatch = objectMapper.writeValueAsString(batch)
+
+		makePostRequest(
+			"$apiHost:$port$apiEndpoint",
+			stringBatch.replace("\\[ *\"DUMMY_REGION\" *]".toRegex(), "\"DUMMY\""), 400
+		)
+
+		// Check that none of the new codes exist in the DB
+		val newCodesInDB = codeLogic.getCodes(batch.map { it.id })
+		runBlocking {
+			assertEquals(0, newCodesInDB.count())
+		}
+	}
+
+	@Test
+	fun batchCreationFailsIfQualifiedLinksIsNotAMap() {
+		val batch = codeGenerator.createBatchOfUniqueCodes(batchSize) + CodeDto(
+			id = "DUMMY_TYPE|DUMMY_CODE|DUMMY_VERSION",
+			type = "DUMMY_TYPE",
+			code = "DUMMY_CODE",
+			version = "DUMMY_VERSION",
+			qualifiedLinks = mapOf("DUMMY_TYPE" to listOf("DUMMY_CODE"))
+		)
+		val stringBatch = objectMapper.writeValueAsString(batch)
+
+		makePostRequest(
+			"$apiHost:$port$apiEndpoint",
+			stringBatch.replace("\\{ *\"DUMMY_TYPE\" *: *\\[ *\"DUMMY_CODE\" *] *}".toRegex(), "\"DUMMY\""), 400
+		)
+
+		// Check that none of the new codes exist in the DB
+		val newCodesInDB = codeLogic.getCodes(batch.map { it.id })
+		runBlocking {
+			assertEquals(0, newCodesInDB.count())
+		}
+	}
+
+	@Test
+	fun batchCreationFailsIfSearchTermsIsNotAMap() {
+		val batch = codeGenerator.createBatchOfUniqueCodes(batchSize) + CodeDto(
+			id = "DUMMY_TYPE|DUMMY_CODE|DUMMY_VERSION",
+			type = "DUMMY_TYPE",
+			code = "DUMMY_CODE",
+			version = "DUMMY_VERSION",
+			searchTerms = mapOf("DUMMY_LANG" to setOf("DUMMY_TERM"))
+		)
+		val stringBatch = objectMapper.writeValueAsString(batch)
+
+		makePostRequest(
+			"$apiHost:$port$apiEndpoint",
+			stringBatch.replace("\\{ *\"DUMMY_LANG\" *: *\\[ *\"DUMMY_TERM\" *] *}".toRegex(), "\"DUMMY\""), 400
+		)
+
+		// Check that none of the new codes exist in the DB
+		val newCodesInDB = codeLogic.getCodes(batch.map { it.id })
+		runBlocking {
+			assertEquals(0, newCodesInDB.count())
+		}
+	}
+}

--- a/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeBatchCreationEndToEndTest.kt
+++ b/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeBatchCreationEndToEndTest.kt
@@ -108,7 +108,7 @@ class CodeBatchCreationEndToEndTest @Autowired constructor(
 
 		// Check that the provided response is correct
 		assertEquals(batch.size, response.size)
-		batch.forEach {
+		response.forEach {
 			assert(batch.contains(it))
 		}
 
@@ -193,7 +193,8 @@ class CodeBatchCreationEndToEndTest @Autowired constructor(
 
 		makePostRequest(
 			"$apiHost:$port$apiEndpoint",
-			stringBatch.replace("\\{ *\"DUMMY_LANG\" *: *\"DUMMY_VAL\" *}".toRegex(), "\"DUMMY\""), 400
+			stringBatch.replace("\\{ *\"DUMMY_LANG\" *: *\"DUMMY_VAL\" *}".toRegex(), "\"DUMMY\""),
+			400
 		)
 
 		// Check that none of the new codes exist in the DB

--- a/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeBatchModificationEndToEndTest.kt
+++ b/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeBatchModificationEndToEndTest.kt
@@ -1,0 +1,307 @@
+package org.taktik.icure.services.external.rest.v1.controllers.core
+
+import java.nio.charset.StandardCharsets
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.SingletonSupport
+import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.test.context.ActiveProfiles
+import org.taktik.icure.asynclogic.CodeLogic
+import org.taktik.icure.test.CodeBatchGenerator
+import org.taktik.icure.test.ICureTestApplication
+import org.taktik.icure.services.external.rest.v1.dto.CodeDto
+import org.taktik.icure.services.external.rest.v1.mapper.base.CodeMapper
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Flux.zip
+import reactor.netty.ByteBufFlux
+import reactor.netty.http.client.HttpClient
+
+@SpringBootTest(
+	classes = [ICureTestApplication::class],
+	properties = ["spring.main.allow-bean-definition-overriding=true"],
+	webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@ActiveProfiles("app")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CodeBatchModificationEndToEndTest @Autowired constructor(
+	private val codeLogic: CodeLogic,
+	private val codeMapper: CodeMapper
+) {
+
+	@LocalServerPort
+	var port = 0
+	val apiHost = System.getenv("ICURE_BE_URL") ?: "http://localhost"
+	val apiEndpoint: String = System.getenv("ENDPOINT_TO_TEST") ?: "/rest/v1"
+	private final val codeGenerator = CodeBatchGenerator()
+	private final val batchSize = 42
+	var existingCodes: List<CodeDto> = listOf()
+
+	val objectMapper: ObjectMapper by lazy {
+		ObjectMapper().registerModule(
+			KotlinModule.Builder()
+				.nullIsSameAsDefault(nullIsSameAsDefault = false)
+				.reflectionCacheSize(reflectionCacheSize = 512)
+				.nullToEmptyMap(nullToEmptyMap = false)
+				.nullToEmptyCollection(nullToEmptyCollection = false)
+				.singletonSupport(singletonSupport = SingletonSupport.DISABLED)
+				.strictNullChecks(strictNullChecks = false)
+				.build()
+		)
+	}
+
+	init {
+		runBlocking {
+			val codes = codeGenerator.createBatchOfUniqueCodes(batchSize)
+			existingCodes = codeLogic.create(codes.map { codeMapper.map(it) })!!.map { codeMapper.map(it) }
+		}
+	}
+
+	fun createHttpClient(): HttpClient {
+		val auth = "Basic ${java.util.Base64.getEncoder().encodeToString("${System.getenv("ICURE_COUCHDB_TEST_USER")}:${System.getenv("ICURE_COUCHDB_TEST_PWD")}".toByteArray())}"
+		return HttpClient.create().headers { h ->
+			h.set("Authorization", auth) //
+			h.set("Content-type", "application/json")
+		}
+	}
+
+	fun makePutRequest(url: String, payload: String, expectedCode: Int = 200): String? {
+		val client = createHttpClient()
+
+		val responseBody = client
+			.put()
+			.uri(url)
+			.send(ByteBufFlux.fromString(Flux.just(payload)))
+			.responseSingle { response, buffer ->
+				assertNotNull(response)
+				assertEquals(expectedCode, response.status().code())
+				buffer.asString(StandardCharsets.UTF_8)
+			}.block()
+
+		return responseBody
+	}
+
+	fun verifyExistingCodes(codes: List<CodeDto>) {
+		runBlocking {
+			codes.forEach {
+				assertEquals(codeMapper.map(it), codeLogic.get(it.id))
+			}
+		}
+	}
+
+	fun verifyCorrectBatch(requestCodes: List<CodeDto>, responseCodes: List<CodeDto>) {
+		// Check that the provided response is correct
+		assertEquals(requestCodes.size, responseCodes.size)
+
+		responseCodes.zip(requestCodes).forEach {
+			assertNotEquals(it.second.rev, it.first.rev)
+			assertEquals(it.second.copy(rev=""), it.first.copy(rev=""))
+		}
+
+		// Check that all the new codes are in the database
+		verifyExistingCodes(responseCodes)
+	}
+
+	@Test
+	fun batchModificationCanChangeLabel() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true) }
+
+		val responseString = makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(modifiedCodes))
+		assertNotNull(responseString)
+		val response = objectMapper.readValue(responseString!!, object : TypeReference<List<CodeDto>>() {})
+
+		verifyCorrectBatch(modifiedCodes, response)
+		existingCodes = response
+	}
+
+	@Test
+	fun batchModificationCanChangeRegion() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = false, modifyRegions = true) }
+
+		val responseString = makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(modifiedCodes))
+		assertNotNull(responseString)
+		val response = objectMapper.readValue(responseString!!, object : TypeReference<List<CodeDto>>() {})
+
+		verifyCorrectBatch(modifiedCodes, response)
+		existingCodes = response
+	}
+
+	@Test
+	fun batchModificationCanChangeQualifiedLinks() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = false, modifyRegions = false, modifyQualifiedLinks = true) }
+
+		val responseString = makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(modifiedCodes))
+		assertNotNull(responseString)
+		val response = objectMapper.readValue(responseString!!, object : TypeReference<List<CodeDto>>() {})
+
+		verifyCorrectBatch(modifiedCodes, response)
+		existingCodes = response
+	}
+
+	@Test
+	fun batchModificationCanChangeSearchTerms() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = false, modifyRegions = false, modifyQualifiedLinks = false, modifySearchTerms = true) }
+
+		val responseString = makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(modifiedCodes))
+		assertNotNull(responseString)
+		val response = objectMapper.readValue(responseString!!, object : TypeReference<List<CodeDto>>() {})
+
+		verifyCorrectBatch(modifiedCodes, response)
+		existingCodes = response
+	}
+
+	@Test
+	fun batchModificationCanChangeMultipleParameters() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+
+		val responseString = makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(modifiedCodes))
+		assertNotNull(responseString)
+		val response = objectMapper.readValue(responseString!!, object : TypeReference<List<CodeDto>>() {})
+
+		verifyCorrectBatch(modifiedCodes, response)
+		existingCodes = response
+	}
+
+	@Test
+	fun batchModificationFailsIfAtLeastOneCodeDoesNotExist() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+		val incorrectBatch = modifiedCodes.subList(1, modifiedCodes.size) + modifiedCodes[0].copy(id = "DUMMYID")
+
+		makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(incorrectBatch), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun batchModificationFailsIfAtLeastOneCodeHasNullType() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+		val incorrectBatch = modifiedCodes.subList(1, modifiedCodes.size) + modifiedCodes[0].copy(type = null)
+
+		makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(incorrectBatch), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun batchModificationFailsIfAtLeastOneCodeModifiesType() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+		val incorrectBatch = modifiedCodes.subList(1, modifiedCodes.size) + modifiedCodes[0].copy(type = "DUMMYTYPE")
+
+		makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(incorrectBatch), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun batchModificationFailsIfAtLeastOneCodeHasNullCode() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+		val incorrectBatch = modifiedCodes.subList(1, modifiedCodes.size) + modifiedCodes[0].copy(code = null)
+
+		makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(incorrectBatch), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun batchModificationFailsIfAtLeastOneCodeModifiesCode() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+		val incorrectBatch = modifiedCodes.subList(1, modifiedCodes.size) + modifiedCodes[0].copy(type = "DUMMYCODE")
+
+		makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(incorrectBatch), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun batchModificationFailsIfAtLeastOneCodeHasNullVersion() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+		val incorrectBatch = modifiedCodes.subList(1, modifiedCodes.size) + modifiedCodes[0].copy(version = null)
+
+		makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(incorrectBatch), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun batchModificationFailsIfAtLeastOneCodeModifiesVersion() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+		val incorrectBatch = modifiedCodes.subList(1, modifiedCodes.size) + modifiedCodes[0].copy(version = "DUMMYVERSION")
+
+		makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(incorrectBatch), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun batchModificationFailsIfLabelIsNotAMap() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+		val incorrectBatch = modifiedCodes.subList(1, modifiedCodes.size) + modifiedCodes[0].copy(label = mapOf("DUMMY_LANG" to "DUMMY_VAL"))
+		val incorrectStringBatch = objectMapper.writeValueAsString(incorrectBatch)
+
+		makePutRequest("$apiHost:$port$apiEndpoint", incorrectStringBatch.replace("\\{ *\"DUMMY_LANG\" *: *\"DUMMY_VAL\" *}".toRegex(), "\"DUMMY\""), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun batchModificationFailsIfRegionsIsNotASet() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+		val incorrectBatch = modifiedCodes.subList(1, modifiedCodes.size) + modifiedCodes[0].copy(regions = setOf("DUMMY_REGION"))
+		val incorrectStringBatch = objectMapper.writeValueAsString(incorrectBatch)
+
+		makePutRequest("$apiHost:$port$apiEndpoint", incorrectStringBatch.replace("\\[ *\"DUMMY_REGION\" *]".toRegex(), "\"DUMMY\""), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun batchModificationFailsIfQualifiedLinksIsNotAMap() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+		val incorrectBatch = modifiedCodes.subList(1, modifiedCodes.size) + modifiedCodes[0].copy(qualifiedLinks = mapOf("DUMMY_TYPE" to listOf("DUMMY_CODE")))
+		val incorrectStringBatch = objectMapper.writeValueAsString(incorrectBatch)
+
+		makePutRequest("$apiHost:$port$apiEndpoint", incorrectStringBatch.replace("\\{ *\"DUMMY_TYPE\" *: *\\[ *\"DUMMY_CODE\" *] *}".toRegex(), "\"DUMMY\""), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun batchModificationFailsIfSearchTermsIsNotAMap() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+		val incorrectBatch = modifiedCodes.subList(1, modifiedCodes.size) + modifiedCodes[0].copy(searchTerms = mapOf("DUMMY_LANG" to setOf("DUMMY_TERM")))
+		val incorrectStringBatch = objectMapper.writeValueAsString(incorrectBatch)
+
+		makePutRequest("$apiHost:$port$apiEndpoint", incorrectStringBatch.replace("\\{ *\"DUMMY_LANG\" *: *\\[ *\"DUMMY_TERM\" *] *}".toRegex(), "\"DUMMY\""), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun emptyBatchLeadsToNoModification() {
+		val responseString = makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(listOf<CodeDto>()))
+		assertNotNull(responseString)
+		val response = objectMapper.readValue(responseString!!, object : TypeReference<List<CodeDto>>() {})
+		assertEquals(0, response.size)
+		verifyExistingCodes(existingCodes)
+	}
+
+	@Test
+	fun batchModificationWithDuplicateCodeFails() {
+		val modifiedCodes = existingCodes.map { codeGenerator.randomCodeModification(it, modifyLabel = true, modifyRegions = true, modifyQualifiedLinks = true, modifySearchTerms = true) }
+
+		makePutRequest("$apiHost:$port$apiEndpoint", objectMapper.writeValueAsString(modifiedCodes + modifiedCodes[0]), 400)
+
+		verifyExistingCodes(existingCodes)
+	}
+
+
+}

--- a/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeBatchModificationEndToEndTest.kt
+++ b/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/CodeBatchModificationEndToEndTest.kt
@@ -5,11 +5,10 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.SingletonSupport
-import kotlinx.coroutines.flow.count
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
@@ -17,10 +16,10 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.test.context.ActiveProfiles
 import org.taktik.icure.asynclogic.CodeLogic
-import org.taktik.icure.test.CodeBatchGenerator
-import org.taktik.icure.test.ICureTestApplication
 import org.taktik.icure.services.external.rest.v1.dto.CodeDto
 import org.taktik.icure.services.external.rest.v1.mapper.base.CodeMapper
+import org.taktik.icure.test.CodeBatchGenerator
+import org.taktik.icure.test.ICureTestApplication
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Flux.zip
 import reactor.netty.ByteBufFlux
@@ -43,7 +42,7 @@ class CodeBatchModificationEndToEndTest @Autowired constructor(
 	val apiHost = System.getenv("ICURE_BE_URL") ?: "http://localhost"
 	val apiEndpoint: String = System.getenv("ENDPOINT_TO_TEST") ?: "/rest/v1"
 	private final val codeGenerator = CodeBatchGenerator()
-	private final val batchSize = 42
+	private final val batchSize = 1001
 	var existingCodes: List<CodeDto> = listOf()
 
 	val objectMapper: ObjectMapper by lazy {
@@ -104,7 +103,7 @@ class CodeBatchModificationEndToEndTest @Autowired constructor(
 
 		responseCodes.zip(requestCodes).forEach {
 			assertNotEquals(it.second.rev, it.first.rev)
-			assertEquals(it.second.copy(rev=""), it.first.copy(rev=""))
+			assertEquals(it.second.copy(rev = ""), it.first.copy(rev = ""))
 		}
 
 		// Check that all the new codes are in the database
@@ -302,6 +301,4 @@ class CodeBatchModificationEndToEndTest @Autowired constructor(
 
 		verifyExistingCodes(existingCodes)
 	}
-
-
 }

--- a/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/VersionFilterEndToEndTest.kt
+++ b/src/test/kotlin/org/taktik/icure/services/external/rest/v1/controllers/core/VersionFilterEndToEndTest.kt
@@ -2,30 +2,30 @@ package org.taktik.icure.services.external.rest.v1.controllers.core
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.SingletonSupport
-import com.fasterxml.jackson.core.type.TypeReference
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.Test
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.web.server.LocalServerPort
-import org.springframework.test.context.ActiveProfiles
-import reactor.netty.http.client.HttpClient
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.web.server.LocalServerPort
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver
+import org.springframework.test.context.ActiveProfiles
 import org.taktik.icure.asynclogic.CodeLogic
 import org.taktik.icure.entities.base.Code
 import org.taktik.icure.services.external.rest.v1.dto.CodeDto
 import org.taktik.icure.services.external.rest.v1.dto.PaginatedList
 import org.taktik.icure.test.ICureTestApplication
 import org.taktik.icure.test.removeEntities
+import reactor.netty.http.client.HttpClient
 
 @SpringBootTest(
 	classes = [ICureTestApplication::class],
@@ -34,9 +34,9 @@ import org.taktik.icure.test.removeEntities
 )
 @ActiveProfiles("app")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class CodeControllerEndToEndTest @Autowired constructor(
+class VersionFilterEndToEndTest @Autowired constructor(
 	private val codeLogic: CodeLogic
-	) {
+) {
 
 	@LocalServerPort
 	var port = 0
@@ -75,7 +75,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 
 		val countVersions = mutableMapOf<String, MutableList<String>>()
 		resolver.getResources("classpath*:/org/taktik/icure/db/codes/codes-test-version-filter.json").forEach {
-			objectMapper?.readValue(it.inputStream, object: TypeReference<List<Code>>() {})?.forEach { code ->
+			objectMapper?.readValue(it.inputStream, object : TypeReference<List<Code>>() {})?.forEach { code ->
 				codesStats["total"] = (codesStats["total"] as Int) + 1
 				(codesStats["count"] as MutableMap<String, Int>)[code.version ?: "NO_VERSION"] = (codesStats["count"] as Map<String, Int>)[code.version ?: "NO_VERSION"]?.plus(1) ?: 1
 				codesStats["ids"] = (codesStats["ids"] as List<String>) + code.id
@@ -83,10 +83,9 @@ class CodeControllerEndToEndTest @Autowired constructor(
 				else countVersions[code.code ?: "NO_CODE"]?.add(code.version ?: "NO_VERSION")
 			}
 		}
-		countVersions.forEach{ (k, v) ->
+		countVersions.forEach { (k, v) ->
 			codesStats["latest"] = (codesStats["latest"] as Map<String, String>) + (k to (v.maxOrNull() ?: "NO_VERSION"))
 		}
-
 	}
 
 	fun makeGetRequest(url: String): PaginatedList<CodeDto>? {
@@ -103,7 +102,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		}.block()
 
 		assertNotNull(responseBody)
-		return objectMapper?.readValue(responseBody, object: TypeReference<PaginatedList<CodeDto>>() {})
+		return objectMapper?.readValue(responseBody, object : TypeReference<PaginatedList<CodeDto>>() {})
 	}
 
 	fun testPaginationFewResults(version: String, url: String, expectedRows: Int) {
@@ -223,13 +222,13 @@ class CodeControllerEndToEndTest @Autowired constructor(
 	fun testRegionVersionFilter() {
 		val region = "fr"
 		val version = "2"
-		testVersionSinglePage(version, (codesStats["count"] as Map<String, Int>)[version] ?: 0,"region=$region")
+		testVersionSinglePage(version, (codesStats["count"] as Map<String, Int>)[version] ?: 0, "region=$region")
 	}
 
 	@Test
 	fun testRegionVersionLatestFilter() {
 		val region = "fr"
-		testVersionSinglePage("latest", (codesStats["latest"] as Map<String, Int>).size,"region=$region")
+		testVersionSinglePage("latest", (codesStats["latest"] as Map<String, Int>).size, "region=$region")
 	}
 
 	//If I specify region, language and version, then I should get only results for that version
@@ -255,7 +254,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val language = "en"
 		val type = "testCode"
 		val version = "2"
-		testVersionSinglePage(version, (codesStats["count"] as Map<String, Int>)[version] ?: 0,"region=$region&language=$language&types=$type")
+		testVersionSinglePage(version, (codesStats["count"] as Map<String, Int>)[version] ?: 0, "region=$region&language=$language&types=$type")
 	}
 
 	@Test
@@ -263,7 +262,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val region = "fr"
 		val language = "en"
 		val type = "testCode"
-		testVersionSinglePage("latest", (codesStats["latest"] as Map<String, Int>).size,"region=$region&language=$language&types=$type")
+		testVersionSinglePage("latest", (codesStats["latest"] as Map<String, Int>).size, "region=$region&language=$language&types=$type")
 	}
 
 	//From now on, I just test with and without type, because is the only one that calls a different method
@@ -273,14 +272,14 @@ class CodeControllerEndToEndTest @Autowired constructor(
 	fun testVersionFilterPaginationFewResults() {
 		val version = "2"
 		val expectedRows = (codesStats["count"] as Map<String, Int>)[version] ?: 0
-		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&limit=${expectedRows+2}", expectedRows)
+		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&limit=${expectedRows + 2}", expectedRows)
 	}
 
 	@Test
 	fun testVersionLatestFilterPaginationFewResults() {
 		val version = "latest"
 		val expectedRows = (codesStats["latest"] as Map<String, Int>).size
-		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&limit=${expectedRows+2}", expectedRows)
+		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&limit=${expectedRows + 2}", expectedRows)
 	}
 
 	//If the number of elements in the db is less than the page size, all elements are in the same page
@@ -289,7 +288,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val version = "2"
 		val expectedRows = (codesStats["count"] as Map<String, Int>)[version] ?: 0
 		val type = "testCode"
-		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&type=$type&limit=${expectedRows+2}", expectedRows)
+		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&type=$type&limit=${expectedRows + 2}", expectedRows)
 	}
 
 	@Test
@@ -297,7 +296,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val version = "latest"
 		val expectedRows = (codesStats["latest"] as Map<String, Int>).size
 		val type = "testCode"
-		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&type=$type&limit=${expectedRows+2}", expectedRows)
+		testPaginationFewResults(version, "$apiHost:$port$apiEndpoint?version=$version&type=$type&limit=${expectedRows + 2}", expectedRows)
 	}
 
 	//Test the pagination using only the version filter. The second page is not full
@@ -307,7 +306,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val expectedRows = (codesStats["count"] as Map<String, Int>)[version] ?: 0
 		assertEquals(expectedRows >= 4, true)
 		val limit: Int = (expectedRows / 2) + (expectedRows / 4)
-		testResultsOnTwoPages(version, "limit=$limit",limit, expectedRows-limit)
+		testResultsOnTwoPages(version, "limit=$limit", limit, expectedRows - limit)
 	}
 
 	@Test
@@ -315,9 +314,8 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		val expectedRows = (codesStats["latest"] as Map<String, Int>).size
 		assertEquals(expectedRows >= 4, true)
 		val limit: Int = (expectedRows / 2) + (expectedRows / 4)
-		testResultsOnTwoPages("latest", "limit=$limit",limit, expectedRows-limit)
+		testResultsOnTwoPages("latest", "limit=$limit", limit, expectedRows - limit)
 	}
-
 
 	//Test the pagination using the version and type filter. The second page is not full
 	@Test
@@ -327,7 +325,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		assertEquals(expectedRows >= 4, true)
 		val limit: Int = (expectedRows / 2) + (expectedRows / 4)
 		val type = "code"
-		testResultsOnTwoPages("2", "limit=$limit&types=$type", limit, expectedRows-limit)
+		testResultsOnTwoPages("2", "limit=$limit&types=$type", limit, expectedRows - limit)
 	}
 
 	@Test
@@ -336,7 +334,7 @@ class CodeControllerEndToEndTest @Autowired constructor(
 		assertEquals(expectedRows >= 4, true)
 		val limit: Int = (expectedRows / 2) + (expectedRows / 4)
 		val type = "code"
-		testResultsOnTwoPages("latest", "limit=$limit&types=$type", limit, expectedRows-limit)
+		testResultsOnTwoPages("latest", "limit=$limit&types=$type", limit, expectedRows - limit)
 	}
 
 	//Test the pagination using the version filter. The second page is full
@@ -344,28 +342,28 @@ class CodeControllerEndToEndTest @Autowired constructor(
 	fun testVersionFilterPaginationFewResultsSecondPageFull() {
 		var version: String? = null
 		var limit = 0
-		(codesStats["count"] as Map<String, Int>).forEach{ (k,v) ->
+		(codesStats["count"] as Map<String, Int>).forEach { (k, v) ->
 			if (v % 2 == 0) {
 				version = k
 				limit = v / 2
 			}
 		}
 		assertNotNull(version)
-		testResultsOnTwoPages(version!!, "limit=$limit",limit, limit)
+		testResultsOnTwoPages(version!!, "limit=$limit", limit, limit)
 	}
 
 	@Test
 	fun testVersionLatestFilterPaginationFewResultsSecondPageFull() {
 		val expectedRows = (codesStats["latest"] as Map<String, Int>).size
-		assertEquals(expectedRows%2, 0)
-		testResultsOnTwoPages("latest", "limit=${expectedRows/2}",expectedRows/2, expectedRows/2)
+		assertEquals(expectedRows % 2, 0)
+		testResultsOnTwoPages("latest", "limit=${expectedRows / 2}", expectedRows / 2, expectedRows / 2)
 	}
 
 	@Test
 	fun testVersionTypeFilterPaginationFewResultsSecondPageFull() {
 		var version: String? = null
 		var limit = 0
-		(codesStats["count"] as Map<String, Int>).forEach{ (k,v) ->
+		(codesStats["count"] as Map<String, Int>).forEach { (k, v) ->
 			if (v % 2 == 0) {
 				version = k
 				limit = v / 2
@@ -379,9 +377,9 @@ class CodeControllerEndToEndTest @Autowired constructor(
 	@Test
 	fun testVersionLatestTypeFilterPaginationFewResultsSecondPageFull() {
 		val expectedRows = (codesStats["latest"] as Map<String, Int>).size
-		assertEquals(expectedRows%2, 0)
+		assertEquals(expectedRows % 2, 0)
 		val type = "code"
-		testResultsOnTwoPages("latest", "limit=${expectedRows/2}&types=$type", expectedRows/2, expectedRows/2)
+		testResultsOnTwoPages("latest", "limit=${expectedRows / 2}&types=$type", expectedRows / 2, expectedRows / 2)
 	}
 
 	@AfterAll
@@ -390,6 +388,4 @@ class CodeControllerEndToEndTest @Autowired constructor(
 			removeEntities(codesStats["ids"] as List<String>, objectMapper)
 		}
 	}
-
-
 }

--- a/src/test/kotlin/org/taktik/icure/test/ICureTestApplication.kt
+++ b/src/test/kotlin/org/taktik/icure/test/ICureTestApplication.kt
@@ -2,7 +2,6 @@ package org.taktik.icure.test
 
 import javax.annotation.PreDestroy
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.reactive.asFlow

--- a/src/test/kotlin/org/taktik/icure/test/ICureTestApplication.kt
+++ b/src/test/kotlin/org/taktik/icure/test/ICureTestApplication.kt
@@ -77,11 +77,15 @@ class ICureTestApplication {
 				.block()
 		} catch (e: Exception) { // If not, I use docker to create a container
 			println("Starting docker")
-			ProcessBuilder(("docker run " +
-				"-p $dbPort:5984 " +
-				"-e COUCHDB_USER=${System.getenv("ICURE_COUCHDB_USERNAME")} -e COUCHDB_PASSWORD=${System.getenv("ICURE_COUCHDB_PASSWORD")} " +
-				"-d --name couchdb-test-instance " +
-				"couchdb:3.2.2").split(' '))
+			ProcessBuilder(
+				(
+					"docker run " +
+						"-p $dbPort:5984 " +
+						"-e COUCHDB_USER=${System.getenv("ICURE_COUCHDB_USERNAME")} -e COUCHDB_PASSWORD=${System.getenv("ICURE_COUCHDB_PASSWORD")} " +
+						"-d --name couchdb-test-instance " +
+						"couchdb:3.2.2"
+					).split(' ')
+			)
 				.start()
 				.waitFor()
 
@@ -109,7 +113,7 @@ class ICureTestApplication {
 				userLogic.newUser(Users.Type.database, System.getenv("ICURE_COUCHDB_TEST_USER"), System.getenv("ICURE_COUCHDB_TEST_PWD"), "icure")// Creates a test user if it does not exist
 			} catch (e: DuplicateDocumentException) {
 				log.info("Test user already exists!")
-			}finally {
+			} finally {
 				log.info("iCure test user\nusername: ${System.getenv("ICURE_COUCHDB_TEST_USER")}\npassword: ${System.getenv("ICURE_COUCHDB_TEST_PWD")}")
 			}
 		}

--- a/src/test/kotlin/org/taktik/icure/test/TestUtils.kt
+++ b/src/test/kotlin/org/taktik/icure/test/TestUtils.kt
@@ -44,6 +44,7 @@ class CodeBatchGenerator {
 	private val alphabet: List<Char> = ('a'..'z').toList() + ('A'..'Z') + ('0'..'9')
 	private val languages = listOf("en", "fr", "nl")
 	private val types = listOf("SNOMED", "LOINC", "TESTCODE", "DEEPSECRET")
+	private val regions = listOf("int", "fr", "be")
 
 	private fun generateRandomString(length: Int) = (1..length)
 		.map { _ -> alphabet[nextInt(0, alphabet.size)] }
@@ -62,9 +63,24 @@ class CodeBatchGenerator {
 				code = code,
 				version = version,
 				label = if (nextInt(0, 4) == 0) mapOf(lang to generateRandomString(nextInt(20, 100))) else mapOf(),
-				regions = if (nextInt(0, 4) == 0) setOf("int") else setOf(),
+				regions = if (nextInt(0, 4) == 0) setOf(regions[nextInt(0, regions.size)]) else setOf(),
 				qualifiedLinks = if (nextInt(0, 4) == 0) mapOf(generateRandomString(10) to List(nextInt(1, 4)) { generateRandomString(10) }) else mapOf(),
 				searchTerms = if (nextInt(0, 4) == 0) mapOf(generateRandomString(10) to List(nextInt(1, 4)) { generateRandomString(10) }.toSet()) else mapOf(),
 			)
+		}
+
+	fun randomCodeModification(code: CodeDto, modifyLabel: Boolean = false, modifyRegions: Boolean = false, modifyQualifiedLinks: Boolean = false, modifySearchTerms: Boolean = false) = code
+		.let {
+			if (modifyLabel && nextInt(0, 4) == 0) it.copy(label = mapOf(languages[nextInt(0, languages.size)] to generateRandomString(nextInt(20, 100))))
+			else it
+		}.let {
+			if (modifyRegions && nextInt(0, 4) == 0) it.copy(regions = setOf(regions[nextInt(0, regions.size)]))
+			else it
+		}.let {
+			if (modifyQualifiedLinks && nextInt(0, 4) == 0) it.copy(qualifiedLinks = mapOf(generateRandomString(10) to List(nextInt(1, 4)) { generateRandomString(10) }))
+			else it
+		}.let {
+			if (modifySearchTerms && nextInt(0, 4) == 0) it.copy(searchTerms = mapOf(generateRandomString(10) to List(nextInt(1, 4)) { generateRandomString(10) }.toSet()))
+			else it
 		}
 }

--- a/src/test/kotlin/org/taktik/icure/test/TestUtils.kt
+++ b/src/test/kotlin/org/taktik/icure/test/TestUtils.kt
@@ -2,11 +2,13 @@ package org.taktik.icure.test
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import kotlin.random.Random.Default.nextInt
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.reactive.awaitFirstOrNull
+import org.taktik.icure.services.external.rest.v1.dto.CodeDto
 import reactor.core.publisher.Mono
 import reactor.netty.http.client.HttpClient
 
@@ -16,7 +18,7 @@ private data class IdWithRev(@field:JsonProperty("_id") val id: String, @field:J
 suspend fun removeEntities(ids: List<String>, objectMapper: ObjectMapper?) {
 	val auth = "Basic ${java.util.Base64.getEncoder().encodeToString("${System.getenv("ICURE_COUCHDB_USERNAME")}:${System.getenv("ICURE_COUCHDB_PASSWORD")}".toByteArray())}"
 	val client = HttpClient.create().headers { h ->
-		h.set("Authorization",auth)
+		h.set("Authorization", auth)
 		h.set("Content-type", "application/json")
 	}
 
@@ -35,4 +37,34 @@ suspend fun removeEntities(ids: List<String>, objectMapper: ObjectMapper?) {
 				} else Mono.empty()
 			}.awaitFirstOrNull()
 	}
+}
+
+class CodeBatchGenerator {
+
+	private val alphabet: List<Char> = ('a'..'z').toList() + ('A'..'Z') + ('0'..'9')
+	private val languages = listOf("en", "fr", "nl")
+	private val types = listOf("SNOMED", "LOINC", "TESTCODE", "DEEPSECRET")
+
+	private fun generateRandomString(length: Int) = (1..length)
+		.map { _ -> alphabet[nextInt(0, alphabet.size)] }
+		.joinToString("")
+
+	fun createBatchOfUniqueCodes(size: Int) = (1..size)
+		.fold(listOf<CodeDto>()) { acc, _ ->
+
+			val lang = languages[nextInt(0, languages.size)]
+			val type = types[nextInt(0, types.size)]
+			val code = generateRandomString(20)
+			val version = nextInt(0, 10).toString()
+			acc + CodeDto(
+				id = "$type|$code|$version",
+				type = type,
+				code = code,
+				version = version,
+				label = if (nextInt(0, 4) == 0) mapOf(lang to generateRandomString(nextInt(20, 100))) else mapOf(),
+				regions = if (nextInt(0, 4) == 0) setOf("int") else setOf(),
+				qualifiedLinks = if (nextInt(0, 4) == 0) mapOf(generateRandomString(10) to List(nextInt(1, 4)) { generateRandomString(10) }) else mapOf(),
+				searchTerms = if (nextInt(0, 4) == 0) mapOf(generateRandomString(10) to List(nextInt(1, 4)) { generateRandomString(10) }.toSet()) else mapOf(),
+			)
+		}
 }


### PR DESCRIPTION
**Batch creation**
The batch creation endpoint can be accessed through the `/code/batch` URL by making a POST request. The body of the request should contain a list of the codes that are to be added. 
The creation fails if at least one of the codes is not in the correct format or if it already exists in the database. In this case, no code from the batch is added.
If successful, the request returns the list of created codes.

**Batch modification**
The batch modification endpoint can be accessed through the `/code/batch` URL by making a PUT request. The body of the request should contain a list of the codes that are to be modified. 
The modification fails if at least one of the codes:
- is not in the correct format
- tries to modify the type, code, or version fields
- does not exist in the database
- is contained multiple times in the batch
If the request fails, no code from the batch is modified.
If successful, the request returns the list of the modified codes.